### PR TITLE
feat(influxv1): render Timeout as config parameter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ const (
 	flagUsername        = influxDBPrefix + "username"
 	flagPassword        = influxDBPrefix + "password"
 	flagUnsafeSsl       = influxDBPrefix + "unsafe_ssl"
+	flagTimeout         = influxDBPrefix + "timeout"
 
 	// InfluxDB v2.x
 	flagToken        = influxDBPrefix + "token" // #nosec
@@ -31,11 +32,12 @@ type Configuration struct {
 	DefaultLookback time.Duration `yaml:"default_lookback"`
 
 	// InfluxDB v1.x
-	Database        string `yaml:"database"`
-	RetentionPolicy string `yaml:"retention_policy"`
-	Username        string `yaml:"username"`
-	Password        string `yaml:"password"`
-	UnsafeSsl       bool   `yaml:"unsafe_ssl"`
+	Database        string        `yaml:"database"`
+	RetentionPolicy string        `yaml:"retention_policy"`
+	Username        string        `yaml:"username"`
+	Password        string        `yaml:"password"`
+	UnsafeSsl       bool          `yaml:"unsafe_ssl"`
+	Timeout         time.Duration `yaml:"timeout"`
 
 	// InfluxDB v2.x
 	Token        string `yaml:"token"`
@@ -47,6 +49,8 @@ type Configuration struct {
 func (c *Configuration) InitFromViper(v *viper.Viper) {
 	c.Host = v.GetString(flagHost)
 	c.DefaultLookback = v.GetDuration(flagDefaultLookback)
+	v.SetDefault(flagTimeout, "5s")
+	c.Timeout = v.GetDuration(flagTimeout)
 
 	c.Database = v.GetString(flagDatabase)
 	c.RetentionPolicy = v.GetString(flagRetentionPolicy)

--- a/storev1/store.go
+++ b/storev1/store.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/influxdata/influxdb1-client"
+	client "github.com/influxdata/influxdb1-client"
 	"github.com/influxdata/jaeger-influxdb/common"
 	"github.com/influxdata/jaeger-influxdb/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
@@ -35,7 +34,7 @@ func NewStore(conf *config.Configuration, logger hclog.Logger) (*Store, func() e
 		URL:       *u,
 		Username:  conf.Username,
 		Password:  conf.Password,
-		Timeout:   5 * time.Second,
+		Timeout:   conf.Timeout,
 		UnsafeSsl: conf.UnsafeSsl,
 		UserAgent: fmt.Sprintf("jaeger-influxdb"),
 	}


### PR DESCRIPTION
It would be great to render the query timeout as a possible parameter as I got a few queries taking more than 5 seconds (mainly due to network connection). 

I added the original 5 seconds as a default viper key, so no user change are expected with this patch.